### PR TITLE
Make tests pass

### DIFF
--- a/src/gpg/verify.py
+++ b/src/gpg/verify.py
@@ -27,7 +27,7 @@ def verify(signature_file, filename):
             signed_time = time.ctime(signature.timestamp)
 
             message = '''
-                      Good signature from {user}
+                      Good signature from "{user}"
                       with key {fingerprint}
                       made at {time}
                       '''.format(user=user,

--- a/tests/t03-init.t
+++ b/tests/t03-init.t
@@ -2,7 +2,6 @@
 
 test_description='Command: init'
 source "$(dirname "$0")"/setup.sh
-extend_test_key_expiration     # make sure that the test key has not expired
 
 test_expect_success 'egpg' '
     [[ ! -d "$HOME/.egpg" ]] &&

--- a/tests/t10-verify.t
+++ b/tests/t10-verify.t
@@ -25,7 +25,7 @@ test_expect_success 'egpg verify (missing file)' '
 
 test_expect_success 'egpg verify' '
     echo "Test 1" > test1.txt &&
-    egpg verify test1.txt.signature 2>&1 | grep "gpg: Good signature from \"Test 1 <test1@example.org>\""
+    egpg verify test1.txt.signature 2>&1 | grep "Good signature from \"Test 1 <test1@example.org>\""
 '
 
 test_done

--- a/tests/t24-key-pass.t
+++ b/tests/t24-key-pass.t
@@ -12,7 +12,7 @@ test_expect_success 'egpg key pass' '
 
     echo "Test 1" > test1.txt &&
     egpg sign test1.txt &&
-    egpg verify test1.txt.signature 2>&1 | grep "gpg: Good signature"
+    egpg verify test1.txt.signature 2>&1 | grep "Good signature"
 '
 
 test_done

--- a/tests/t34-split-key.t
+++ b/tests/t34-split-key.t
@@ -24,7 +24,7 @@ test_expect_success 'egpg sign' '
 '
 
 test_expect_success 'egpg verify' '
-    egpg verify test1.txt.signature 2>&1 | grep "gpg: Good signature from \"Test 1 <test1@example.org>\""
+    egpg verify test1.txt.signature 2>&1 | grep "Good signature from \"Test 1 <test1@example.org>\""
 '
 
 test_expect_success 'egpg seal' '


### PR DESCRIPTION
Helps with #63 

Though not all tests pass; specifically the ones mentioned in EasyGnuPG/egpg#56 don't pass.
Tests for the features added up to f181139480eefdac5fbc4a0e1797d9473993f1f0 pass.
Not tested/updated for #60 and #61 yet.

Also there are cases when the test don't pass for the first time (t03-init) I spring up the container and I get the error that key not found. But they pass the second time and further. What I have currently figured out is that there are certain files(keys) added to tests/gnupg after t03 which make them run the second and further time. (I'll work this out in a while)
This was the reason they didn't work the first time yesterday but when I copied the egpg/tests directory to pgpg and run a couple of times and they started working.