### PR TITLE
try automated testing using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - git clone "https://github.com/diveshuttam/ds"
+  - cd ds
+  - sudo make install
+  - rm -rf ds
+  - cd -
+  - sudo git clone --branch bionic "https://github.com/easygnupg/pgpg-ds" "/opt/docker-scripts/pgpg-bionic"
+  - sudo ds init pgpg-bionic @pgpg-bionic
+
+install:
+  - pwd
+  - sudo mkdir -p /var/ds/pgpg-bionic/pgpg/
+  - sudo cp -r ./* /var/ds/pgpg-bionic/pgpg/
+  - cd "/var/ds/pgpg-bionic/"
+  - sudo ds make
+
+script:
+  - sudo ds inject run-tests.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_install:
   - git clone "https://github.com/diveshuttam/ds"
   - cd ds
   - sudo make install
-  - rm -rf ds
   - cd -
+  - rm -rf ds
   - sudo git clone --branch bionic "https://github.com/easygnupg/pgpg-ds" "/opt/docker-scripts/pgpg-bionic"
   - sudo ds init pgpg-bionic @pgpg-bionic
 


### PR DESCRIPTION
closes #73 
Though I was planning to add this later but I came across this yesterday and found it easy to setup. 
I tried this on my own fork first and you can find its log here:
https://travis-ci.com/diveshuttam/pgpg/jobs/132191798

It will help us as all 3 of us won't require to run tests only I have to run while testing, you can just look at the logs. It will save my overall time too as I might not run all tests but just the required ones locally. 

You will have to install travis on this organization and this should start working.

I am currently using my fork of docker-scripts instead of `docker-scripts/ds` version as travis determines the pass and fail status by the exit code which was always 0 in `ds inject run-tests.sh`. 
You can have a look at following changes if it ok to incorporate them in docker-scripts, I can use the main repo also. Didn't create a PR there as I don't have all the testing and other setup for ds yet so haven't tested this.
https://github.com/diveshuttam/ds/commit/e91cdfab959aeed9c752602bcb138c82082d5561